### PR TITLE
Adding a pointer format modifier

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,12 @@ jsonfile.readFile(file, function (err, obj) {
       if (parseField === 'updatedAt') {
         parseItem['updated_at'] = { '$date': parseItem['updatedAt'] }
       }
+      
+      var value = parseItem[parseField]
+      if (value != null && typeof value === 'object' && value['__type'] == 'Pointer') {
+          parseItem['_p_' + parseField] = value['className'] + '$' + value['objectId']
+          delete parseItem[parseField]
+      }
     }
     newArray.push(parseItem)
   }


### PR DESCRIPTION
Hello, I found this module useful to restore a parse database that only existed as a set of json files.
It mostly worked except that relational queries were returning 0 objects. After some research I found that the culprit was the format of the pointers.  After re-importing with this change relational queries are working properly. The format change is the following:

original: 
    "parentInspection": { "__type": "Pointer", "className": "NameOfClass", "objectId": "PNLEniZswJ" }

should be:
    "_p_parentInspection": "NameOfClass$yGts7DGTry"
